### PR TITLE
Cleaned up view of popup screens & toggled off the TabNavigator animation.

### DIFF
--- a/Badmeat/src/Router.js
+++ b/Badmeat/src/Router.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { TabNavigator, TabBarBottom } from 'react-navigation';
-import { Icon } from 'react-native-elements';
+import {TabNavigator, TabBarBottom} from 'react-navigation';
+import {Icon} from 'react-native-elements';
 
 // Screen Imports
 import Dashboard from './components/Dashboard';
@@ -15,12 +15,12 @@ const Router = TabNavigator(
       screen: Dashboard,
       path: '',
       navigationOptions: {
-        tabBarIcon: ({ tintColor }) => (
+        tabBarIcon: ({tintColor}) => (
           <Icon
             name='collage'
             type="material-community"
             size={28}
-            color={tintColor} />
+            color={tintColor}/>
         ),
       }
     },
@@ -28,12 +28,12 @@ const Router = TabNavigator(
       screen: Map,
       path: '',
       navigationOptions: {
-        tabBarIcon: ({ tintColor }) => (
+        tabBarIcon: ({tintColor}) => (
           <Icon
             name='map-marker-radius'
             type="material-community"
             size={28}
-            color={tintColor} />
+            color={tintColor}/>
         )
       }
     },
@@ -41,12 +41,12 @@ const Router = TabNavigator(
       screen: Camera,
       path: '',
       navigationOptions: {
-        tabBarIcon: ({ tintColor }) => (
+        tabBarIcon: ({tintColor}) => (
           <Icon
             name='camera-iris'
             type="material-community"
             size={28}
-            color={tintColor} />
+            color={tintColor}/>
         ),
       }
     },
@@ -54,12 +54,12 @@ const Router = TabNavigator(
       screen: Notifications,
       path: '',
       navigationOptions: {
-        tabBarIcon: ({ tintColor }) => (
+        tabBarIcon: ({tintColor}) => (
           <Icon
             name='bell'
             type="material-community"
             size={28}
-            color={tintColor} />
+            color={tintColor}/>
         )
       }
     },
@@ -67,22 +67,24 @@ const Router = TabNavigator(
       screen: Pantry,
       path: '',
       navigationOptions: {
-        tabBarIcon: ({ tintColor }) => (
+        tabBarIcon: ({tintColor}) => (
           <Icon
             name='food-apple'
             type="material-community"
             size={28}
-            color={tintColor} />
+            color={tintColor}/>
         )
       }
     },
   },
   {
-      tabBarPosition: 'bottom',
-      tabBarComponent: TabBarBottom,
+    tabBarPosition: 'bottom',
+    tabBarComponent: TabBarBottom,
+    animationEnabled: false,
+    swipeEnabled: true,
     tabBarOptions: {
 
-        showIcon: true,
+      showIcon: true,
       showLabel: false,
       activeTintColor: '#42a5f5',
     },

--- a/Badmeat/src/components/common/Header.js
+++ b/Badmeat/src/components/common/Header.js
@@ -8,6 +8,7 @@ import {NewEntryDialogue} from "./NewEntryDialogue";
 const Header = (props) => {
   const { textStyle, viewStyle, container } = styles;
   let newEntryButtonContent = <NewEntryDialogue/>;
+
   if (props.button1 === "plus") {
     return (
       <View style={container}>
@@ -19,7 +20,7 @@ const Header = (props) => {
           activeOpacity={0.7}
         />
         <Text style={textStyle}>{props.headerText}</Text>
-        <HeaderButton iconName={props.button1} content={newEntryButtonContent}/>
+        <HeaderButton iconName={props.button1} content={newEntryButtonContent} title="Add New Entry"/>
         <HeaderButton iconName={props.button2} />
       </View>
     );

--- a/Badmeat/src/components/common/HeaderButton.js
+++ b/Badmeat/src/components/common/HeaderButton.js
@@ -3,6 +3,23 @@ import { TouchableOpacity, StyleSheet,View, Text, Modal} from 'react-native';
 import { Icon } from 'react-native-elements';
 import {NewEntryDialogue} from "./NewEntryDialogue";
 
+const styles = StyleSheet.create({
+  header:{
+
+    flexDirection: "row",
+    alignItems:"flex-start",
+    paddingLeft: 10,
+    paddingBottom: 10,
+    paddingTop: 10,
+    backgroundColor:'#42a5f5'
+  },
+  headerText:{
+    color: "#eceff1",
+    fontSize: 20,
+
+  }
+});
+
 class HeaderButton extends Component {
   state= {
     modalVisible: false
@@ -22,17 +39,18 @@ class HeaderButton extends Component {
           onRequestClose={() => {console.log("Modal has been closed")}}
         >
           <View>
-            <View style = {{ alignItems: "flex-start", paddingLeft: 10,paddingTop: 10, paddingBottom: 10, backgroundColor:'#42a5f5'}}>
-              <TouchableOpacity onPress={() => {
+            <View style = {styles.header}>
+              <TouchableOpacity style={{marginRight:30}} onPress={() => {
                 this.setModalVisible(!this.state.modalVisible)
               }}>
                 <Icon
                   name={"arrow-left"}
                   type="material-community"
-                  size={28}
+                  size={25}
                   color="#eceff1"
                 />
               </TouchableOpacity>
+              <Text style={styles.headerText}>{this.props.title}</Text>
             </View>
             <View style = {{ padding:10}}>
               {this.props.content}

--- a/Badmeat/src/components/common/HeaderButton.js
+++ b/Badmeat/src/components/common/HeaderButton.js
@@ -22,7 +22,7 @@ class HeaderButton extends Component {
           onRequestClose={() => {console.log("Modal has been closed")}}
         >
           <View>
-            <View style = {{ paddingTop: 10, paddingBottom: 10, backgroundColor:'#42a5f5'}}>
+            <View style = {{ alignItems: "flex-start", paddingLeft: 10,paddingTop: 10, paddingBottom: 10, backgroundColor:'#42a5f5'}}>
               <TouchableOpacity onPress={() => {
                 this.setModalVisible(!this.state.modalVisible)
               }}>
@@ -30,6 +30,7 @@ class HeaderButton extends Component {
                   name={"arrow-left"}
                   type="material-community"
                   size={28}
+                  color="#eceff1"
                 />
               </TouchableOpacity>
             </View>

--- a/Badmeat/src/components/common/NewEntryDialogue.js
+++ b/Badmeat/src/components/common/NewEntryDialogue.js
@@ -9,16 +9,14 @@ const styles = StyleSheet.create({
   container:{
     marginRight: 10,
   },
-  title:{
-    fontSize: 24
-  }
+
 });
 
 class NewEntryDialogue extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <Text style={styles.title}>Add New Entry</Text>
+        <Text >Enter details or use the camera!</Text>
       </View>
     );
   }

--- a/Badmeat/src/components/common/NewEntryDialogue.js
+++ b/Badmeat/src/components/common/NewEntryDialogue.js
@@ -2,16 +2,23 @@
  * Created by deonj on 8/24/2017.
  */
 import React, {Component} from 'react';
-import { Modal, Text, TouchableOpacity, View } from 'react-native';
+import { Modal, Text, TouchableOpacity, View, StyleSheet } from 'react-native';
 import {Icon} from 'react-native-elements'
 
+const styles = StyleSheet.create({
+  container:{
+    marginRight: 10,
+  },
+  title:{
+    fontSize: 24
+  }
+});
+
 class NewEntryDialogue extends Component {
-
-
   render() {
     return (
-      <View style={{marginRight: 10}}>
-        <Text>ayyyyyy! Time to add some more food!</Text>
+      <View style={styles.container}>
+        <Text style={styles.title}>Add New Entry</Text>
       </View>
     );
   }


### PR DESCRIPTION
Left aligned the back button and changed its icon color to white (Matches header buttons and app theme). Changed title on new entry popup screen. Turned off animation for TabNavigator. We can see if this helps the performance or not, but I was worried that the animation was slowing things down. I left the swiping between screens enabled.